### PR TITLE
Fix PyPI publishing to be PEP 625 compliant; bump up version

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -15,8 +15,11 @@ jobs:
       with:
         submodules: true
 
-    - name: Build SDist
-      run: pipx run build --sdist
+    - name: Install updated build backend
+      run: python -m pip install --upgrade build
+
+    - name: Build SDist (PEP 625 compliant)
+      run: python -m build --sdist
 
     - name: Check metadata
       run: pipx run twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "zeus-apple-silicon"
-version = "1.0.0"
+version = "1.0.1"
 description = "A library for programmatic, in-code energy measurement on Apple Silicon."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Got this notice from PyPI:

> In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.
> 
> Specifically, your recent upload of 'zeus-apple-silicon-1.0.0.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'zeus_apple_silicon'.
> 
> In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.

This PR attempts to address that.